### PR TITLE
feat(pre-commit): Added config file for `pre-commit`.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: stylua
+        name: StyLua
+        language: system
+        entry: stylua
+        types: [lua]
+        verbose: true

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,12 @@
+syntax = 'Lua51'
+space_after_function_names = "Never"
+indent_type = "Spaces"
+indent_width = 4
+column_width = 100
+line_endings = "Unix"
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"
+collapse_simple_statement = "Never"
+
+[sort_requires]
+enabled = false


### PR DESCRIPTION
## My rationale

`pre-commit` can be used optionally by maintainers to add hooks to run every time a commit is made.
In this case, it runs StyLua to format all Lua files before commit message is saved. In case formatting is needed.

I think these two additions will benefit current and/or future contributors.