### PR TITLE
Corrected `harfbuzz_features` inclusion into `FontAttributes`

### DIFF
--- a/lua/types/init.lua
+++ b/lua/types/init.lua
@@ -477,6 +477,7 @@
 ---@alias Fonts { fonts: FontAttributes[] }
 
 ---@class FontAttributes
+---@field family? string
 -- Whether the font should be a bold variant
 ---@field weight? FontWeight
 ---@field stretch? FontStretch
@@ -489,7 +490,6 @@
 ---@field freetype_load_flags? FreeTypeLoadFlags
 ---@field is_fallback? bool
 ---@field is_synthetic? bool
----@field harfbuzz_features? string[]
 ---@field assume_emoji_presentation? bool
 ---@field scale? number
 


### PR DESCRIPTION
## Changes

- fix(init): `harfbuzz_features` DOESN'T into `FontAttributes`

## Reason

The WezTerm docs are a bit confusing, so I thought
`harfbuzz_features` could also be set inside a `FontAttributes` table.
After testing, it throws an error if it's done that way.

My bad on that.