### PR TITLE
`.luarc.json` cleanup

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,8 +1,13 @@
 {
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
   "workspace.library": ["./lua/types"],
-  "runtime.version": "Lua 5.1",
-  "hint.enable": true,
-  "completion.autoRequire": true,
-  "completion.callSnippet": "Replace",
-  "completion.displayContext": 8
+  "runtime.version": "Lua 5.4",
+  "hint": {
+    "enable": true,
+    "setType": true
+  },
+  "completion": {
+    "callSnippet": "Replace",
+    "displayContext": 8
+  }
 }


### PR DESCRIPTION
## Changes

- fix: allow_square_glyphs_to_overflow_width wrong value
- fix: wezterm runtime is lua 5.4 not 5.1
