### PR TITLE
chore: Use `Lua54` in `.stylua.toml`

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,4 +1,4 @@
-syntax = 'Lua51'
+syntax = 'Lua54'
 space_after_function_names = "Never"
 indent_type = "Spaces"
 indent_width = 4


### PR DESCRIPTION
## Changes

- chore: Use `Lua54` in `.stylua.toml`

We were using `Lua51` instead of `Lua54` for StyLua checking.

Not that it matters much, but better be cautious.