### PR TITLE
Update issue templates, due to ownership transfer

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-missing_types.yml
+++ b/.github/ISSUE_TEMPLATE/1-missing_types.yml
@@ -3,7 +3,6 @@ description: A type is missing/badly implemented? Please tell us
 title: "[TYPE]: <TITLE>"
 labels: ["missing-types", "wrong-types"]
 assignees:
-  - justinsgithub
   - DrKJeff16
 
 body:

--- a/.github/ISSUE_TEMPLATE/2-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.yml
@@ -3,7 +3,6 @@ description: Suggest an idea for this project
 title: "[FEAT]: <TITLE>"
 labels: ["enhancement", "feature"]
 assignees:
-  - justinsgithub
   - DrKJeff16
 
 body:

--- a/.github/ISSUE_TEMPLATE/3-lazydev-bug.yml
+++ b/.github/ISSUE_TEMPLATE/3-lazydev-bug.yml
@@ -1,7 +1,7 @@
-name: LazyDev Bug (Neovim)
+name: Neovim Bug
 description: Is there anything wrong with the Neovim plugin? Tell us!
 title: "[NVIM]: <TITLE>"
-labels: ["bug", "important"]
+labels: ["bug", "important", "neovim"]
 assignees:
   - DrKJeff16
 


### PR DESCRIPTION
## Changes

- fix: Update issue templates, due to ownership transfer

Original Author is not able to tend to repository, so don't assign
him by default in issues, out of respect.